### PR TITLE
fix: Mobile navbar click changes background color

### DIFF
--- a/src/Aaesalamanca.RazorPages/wwwroot/css/site.css
+++ b/src/Aaesalamanca.RazorPages/wwwroot/css/site.css
@@ -54,6 +54,7 @@ a {
   color: var(--accent-color);
   font-weight: 400;
   text-decoration: none;
+  -webkit-tap-highlight-color: transparent;
 }
 
 a:hover {


### PR DESCRIPTION
* iOS devices now doesn't change background color when tapping an anchor.