### PR TITLE
fix: Header shouldn't have a transition between sizes

### DIFF
--- a/src/Aaesalamanca.RazorPages/wwwroot/css/site.css
+++ b/src/Aaesalamanca.RazorPages/wwwroot/css/site.css
@@ -305,7 +305,6 @@ footer {
   }
 
   a {
-    transition: var(--transition-default);
     position: relative;
   }
 


### PR DESCRIPTION
* The header shouldn't have a transition when going from mobile to desktop. The anchors were animated and they shouldn't.