### PR TITLE
docs: Use hyphens instead of PascalCase for YAML front matter

### DIFF
--- a/posts/draft-1.md
+++ b/posts/draft-1.md
@@ -1,8 +1,8 @@
 ---
-publishedDate: 2024-07-15
-editedDate: 2024-07-20
+published-date: 2024-07-15
+edited-date: 2024-07-20
 description: 'Primeros pasos con Razor Pages en .NET 8.'
-isDraft: true
+is-draft: true
 ---
 
 # Introducción a Razor Pages

--- a/posts/draft-2.md
+++ b/posts/draft-2.md
@@ -1,7 +1,7 @@
 ---
-publishedDate: 2024-08-10
+published-date: 2024-08-10
 description: 'Cómo combinar Markdig con highlight.js para resaltar código.'
-isDraft: true
+is-draft: true
 ---
 
 # Trucos con Markdig y highlight.js


### PR DESCRIPTION
* Change from PascalCase to hyphens in YAML front matter.